### PR TITLE
Add support for EvtGetLogInfo

### DIFF
--- a/winlog/wevtapi/wevtapi.go
+++ b/winlog/wevtapi/wevtapi.go
@@ -103,6 +103,22 @@ const (
 	EvtSubscribeActionDeliver = 1
 )
 
+type EvtLogPropertyID uint32
+
+// Windows Event Log Property Enumerations
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa385783(v=vs.85).aspx
+const (
+	// EVT_LOG_PROPERTY_ID
+	EvtLogCreationTime EvtLogPropertyID = iota
+	EvtLogLastAccessTime
+	EvtLogLastWriteTime
+	EvtLogFileSize
+	EvtLogAttributes
+	EvtLogNumberOfLogRecords
+	EvtLogOldestRecordNumber
+	EvtLogFull
+)
+
 // Windows Event Log Constants
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa385781(v=vs.85).aspx
 const (
@@ -172,6 +188,7 @@ const (
 //sys   EvtExportLog(session windows.Handle, path *uint16, query *uint16, targetFilePath *uint16, flags uint32) (err error) = wevtapi.EvtExportLog
 //sys   EvtFormatMessage(pubMetaData windows.Handle, event windows.Handle, messageID uint32, valueCount uint32, variant uintptr, flags uint32, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) = wevtapi.EvtFormatMessage
 //sys   EvtGetChannelConfigProperty(channelConfig windows.Handle, propertyID EvtChannelConfigPropertyID, flags uint32, bufferSize uint32, buffer unsafe.Pointer, bufferUsed *uint32) (err error) = wevtapi.EvtGetChannelConfigProperty
+//sys   EvtGetLogInfo(log windows.Handle, propertyID EvtLogPropertyID, bufferSize uint32, buffer unsafe.Pointer, bufferUsed *uint32) (err error) = wevtapi.EvtGetLogInfo
 //sys   EvtNext(resultSet windows.Handle, eventArraySize uint32, eventArray *windows.Handle, timeout uint32, flags uint32, returned *uint32) (err error) = wevtapi.EvtNext
 //sys   EvtNextChannelPath(channelEnum windows.Handle, channelPathBufferSize uint32, channelPathBuffer *uint16, channelPathBufferUsed *uint32) (err error) = wevtapi.EvtNextChannelPath
 //sys   EvtNextPublisherId(publisherEnum windows.Handle, publisherIDBufferSize uint32, publisherIDBuffer *uint16, publisherIDBufferUsed *uint32) (err error) = wevtapi.EvtNextPublisherId

--- a/winlog/wevtapi/zwevtapi.go
+++ b/winlog/wevtapi/zwevtapi.go
@@ -64,6 +64,7 @@ var (
 	procEvtExportLog                = modwevtapi.NewProc("EvtExportLog")
 	procEvtFormatMessage            = modwevtapi.NewProc("EvtFormatMessage")
 	procEvtGetChannelConfigProperty = modwevtapi.NewProc("EvtGetChannelConfigProperty")
+	procEvtGetLogInfo               = modwevtapi.NewProc("EvtGetLogInfo")
 	procEvtNext                     = modwevtapi.NewProc("EvtNext")
 	procEvtNextChannelPath          = modwevtapi.NewProc("EvtNextChannelPath")
 	procEvtNextPublisherId          = modwevtapi.NewProc("EvtNextPublisherId")
@@ -132,6 +133,14 @@ func EvtFormatMessage(pubMetaData windows.Handle, event windows.Handle, messageI
 
 func EvtGetChannelConfigProperty(channelConfig windows.Handle, propertyID EvtChannelConfigPropertyID, flags uint32, bufferSize uint32, buffer unsafe.Pointer, bufferUsed *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procEvtGetChannelConfigProperty.Addr(), 6, uintptr(channelConfig), uintptr(propertyID), uintptr(flags), uintptr(bufferSize), uintptr(buffer), uintptr(unsafe.Pointer(bufferUsed)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func EvtGetLogInfo(log windows.Handle, propertyID EvtLogPropertyID, bufferSize uint32, buffer unsafe.Pointer, bufferUsed *uint32) (err error) {
+	r1, _, e1 := syscall.SyscallN(procEvtGetLogInfo.Addr(), uintptr(log), uintptr(propertyID), uintptr(bufferSize), uintptr(buffer), uintptr(unsafe.Pointer(bufferUsed)))
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}


### PR DESCRIPTION
Hi, thanks for this useful library!

I would like to submit a PR for the following patch to enable the use of `EvtGetLogInfo` in [Glazier](https://github.com/google/glazier).
https://github.com/jfut/glazier/commit/84299febfe4ed59543b94e6fb71593e753d123b4

To do so, I need to submit this PR to WinOps. However, [The project home label in WinOps](https://github.com/google/winops) for 'Contributing' appears as 'Closed,' and strangely, the 'Open Issues' link directs to open Pull requests rather than Issues.

Would WinOps be open to accepting this PR?
I have already signed the CLA.